### PR TITLE
DE11297 MTB fqBeatName update so builds

### DIFF
--- a/beater/sophoscentralbeat.go
+++ b/beater/sophoscentralbeat.go
@@ -56,7 +56,7 @@ var (
 const (
 	// ServiceName is the name of the service
 	ServiceName = "sophoscentralbeat"
-	//Environment variable name for fully qualified beat name
+	// FQBeatNamevariable name for fully qualified beat name
 	FQBeatName = "FullyQualifiedBeatName"
 )
 

--- a/beater/sophoscentralbeat.go
+++ b/beater/sophoscentralbeat.go
@@ -103,6 +103,9 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		currentPos.AlertsTimestamp = yesterdayTime
 	}
 	logp.Info("Config fields: %+v", c)
+
+	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
+
 	bt := &Sophoscentralbeat{
 		done:            make(chan struct{}),
 		sophos:          sophos,

--- a/beater/sophoscentralbeat.go
+++ b/beater/sophoscentralbeat.go
@@ -13,6 +13,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/logrhythm/sophoscentralbeat/config"
+	"github.com/logrhythm/sophoscentralbeat/environment"
 	"github.com/logrhythm/sophoscentralbeat/handlers"
 	"github.com/logrhythm/sophoscentralbeat/heartbeat"
 	"github.com/logrhythm/sophoscentralbeat/sophoscentral"
@@ -56,8 +57,6 @@ var (
 const (
 	// ServiceName is the name of the service
 	ServiceName = "sophoscentralbeat"
-	// FQBeatNamevariable name for fully qualified beat name
-	FQBeatName = "FullyQualifiedBeatName"
 )
 
 // New creates an instance of sophoscentralbeat.
@@ -86,7 +85,7 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		logp.Err("Unable to get position Handler %v", err)
 		return nil, err
 	}
-	fqBeatName = os.Getenv(FQBeatName)
+	fqBeatName = os.Getenv(environment.FQBeatName)
 	currentPos := new(scbPosition)
 	poserr := pos.ReadPositionfromFile(currentPos)
 	yesterdayTime := GenerateYesterdayTimeStamp()

--- a/beater/sophoscentralbeat.go
+++ b/beater/sophoscentralbeat.go
@@ -103,9 +103,7 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 		currentPos.AlertsTimestamp = yesterdayTime
 	}
 	logp.Info("Config fields: %+v", c)
-
-	// only on Start beat log fqBeatName value, instead of every PublishEvent action
-	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
+	logp.Info("Fully Qualified Beatname: %s", fqBeatName)
 
 	bt := &Sophoscentralbeat{
 		done:            make(chan struct{}),

--- a/beater/sophoscentralbeat.go
+++ b/beater/sophoscentralbeat.go
@@ -104,6 +104,7 @@ func New(b *beat.Beat, cfg *common.Config) (beat.Beater, error) {
 	}
 	logp.Info("Config fields: %+v", c)
 
+	// only on Start beat log fqBeatName value, instead of every PublishEvent action
 	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 
 	bt := &Sophoscentralbeat{

--- a/environment/constants.go
+++ b/environment/constants.go
@@ -1,0 +1,4 @@
+package environment
+
+//FQBeatName is the name of the environment variable containing fully qualified beat name.
+const FQBeatName = "FullyQualifiedBeatName"

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -2,6 +2,7 @@ package heartbeat
 
 import (
 	"encoding/json"
+	"os"
 	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -29,7 +30,13 @@ const (
 	ServiceRunning = 2
 	//ServiceStopped is a code for stopping a particular service
 	ServiceStopped = 3
+
+	// FQBeatName variable name for fully qualified beat name
+	FQBeatName = "FullyQualifiedBeatName"
 )
+
+// fqBeatName is the fully qualified beat name
+var fqBeatName string
 
 // Status is used for status of heartbeat1
 type Status struct {
@@ -52,6 +59,7 @@ type StatusBeater struct {
 // Start will begin reporting heartbeats through the beats
 func (sb *StatusBeater) Start(stopChan chan struct{}, publish func(event beat.Event)) {
 	go func() {
+		fqBeatName = os.Getenv(FQBeatName)
 		sb.Beat(ServiceStarted, "Service started", publish)
 		for {
 			select {
@@ -100,6 +108,7 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	}
 	publish(event)
 	logp.Info("heartbeat sent")
+	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 
 // NewStatusBeater will return a new StatusBeater with the provided base information

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -9,6 +9,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/logrhythm/sophoscentralbeat/environment"
 )
 
 // Heartbeat is a structure for heartbeat
@@ -30,9 +31,6 @@ const (
 	ServiceRunning = 2
 	//ServiceStopped is a code for stopping a particular service
 	ServiceStopped = 3
-
-	// FQBeatName variable name for fully qualified beat name
-	FQBeatName = "FullyQualifiedBeatName"
 )
 
 // fqBeatName is the fully qualified beat name
@@ -59,7 +57,7 @@ type StatusBeater struct {
 // Start will begin reporting heartbeats through the beats
 func (sb *StatusBeater) Start(stopChan chan struct{}, publish func(event beat.Event)) {
 	go func() {
-		fqBeatName = os.Getenv(FQBeatName)
+		fqBeatName = os.Getenv(environment.FQBeatName)
 		sb.Beat(ServiceStarted, "Service started", publish)
 		for {
 			select {
@@ -108,7 +106,6 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	}
 	publish(event)
 	logp.Info("heartbeat sent")
-	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 
 // NewStatusBeater will return a new StatusBeater with the provided base information

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -57,7 +57,6 @@ type StatusBeater struct {
 // Start will begin reporting heartbeats through the beats
 func (sb *StatusBeater) Start(stopChan chan struct{}, publish func(event beat.Event)) {
 	go func() {
-		fqBeatName = os.Getenv(environment.FQBeatName)
 		sb.Beat(ServiceStarted, "Service started", publish)
 		for {
 			select {
@@ -124,6 +123,9 @@ func NewStatusBeater(serviceName string, interval time.Duration, doneChan chan s
 
 // NewStatusBeaterWithFunc returns a new StatusBeater that uses the provided func as a trigger for sending beats
 func NewStatusBeaterWithFunc(serviceName string, intervalFunc IntervalFunc, doneChan chan struct{}) *StatusBeater {
+
+	fqBeatName = os.Getenv(environment.FQBeatName)
+
 	return &StatusBeater{
 		Name:         serviceName,
 		IntervalFunc: intervalFunc,

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -107,7 +107,7 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	publish(event)
 	logp.Info("heartbeat sent")
 
-	// Same log fqBeatName as SIEM ./internal/pkg/heartbeat/status_beater.go
+	// Same log fqBeatName as SIEM ./internal/pkg/heartbeat/status_beater.go func StatusBeater
 	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -105,9 +105,6 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	}
 	publish(event)
 	logp.Info("heartbeat sent")
-
-	// Same log fqBeatName as SIEM ./internal/pkg/heartbeat/status_beater.go func StatusBeater
-	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 
 // NewStatusBeater will return a new StatusBeater with the provided base information

--- a/heartbeat/status_beater.go
+++ b/heartbeat/status_beater.go
@@ -106,6 +106,9 @@ func (sb *StatusBeater) PublishEvent(logData []byte, publish func(event beat.Eve
 	}
 	publish(event)
 	logp.Info("heartbeat sent")
+
+	// Same log fqBeatName as SIEM ./internal/pkg/heartbeat/status_beater.go
+	logp.Debug("Fully Qualified Beatname: %s", fqBeatName)
 }
 
 // NewStatusBeater will return a new StatusBeater with the provided base information


### PR DESCRIPTION
Update MTB fqBeatName variable and usage so sophoscentralbeat builds
verified build in veracode branch using go.mod and re-generating vendor directory
fqBeatName constant only in environment sub-directory like siem repo
log info fqBeatName at Start Beat (New function)

Do no know if built executable sends MTB tag (fullyqualifiedbeatname) to OC for heartbeat or other messages
When review PR please build sophoscentralbeat